### PR TITLE
Update Training_Models_with_Unequal_Economic_Error_Costs_in_SageMaker…

### DIFF
--- a/custom-loss/Training_Models_with_Unequal_Economic_Error_Costs_in_SageMaker.ipynb
+++ b/custom-loss/Training_Models_with_Unequal_Economic_Error_Costs_in_SageMaker.ipynb
@@ -1462,7 +1462,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We create and execute an Amazon SageMaker training job for the custom 5:1 loss function, that is, custom loss with false positives being 5 times more costly than false positives. By passing the \"loss_function_type\" set to \"custom\" and \"fn_cost\" to \"5\" and \"fp_cost\" to \"1\", respectively, Amazon SageMaker knows to use the custom loss function with the specified misclassification costs."
+    "We create and execute an Amazon SageMaker training job for the custom 5:1 loss function, that is, custom loss with false negatives being 5 times more costly than false positives. By passing the \"loss_function_type\" set to \"custom\" and \"fn_cost\" to \"5\" and \"fp_cost\" to \"1\", respectively, Amazon SageMaker knows to use the custom loss function with the specified misclassification costs."
    ]
   },
   {


### PR DESCRIPTION
….ipynb

pretty sure you mean negatives here being 5x more costly instead of positives.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
